### PR TITLE
feat: Make prompt loading errors fatal

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,8 +12,11 @@ import time
 import threading
 from collections import defaultdict, deque
 from functools import wraps
+import sys
+import yaml
 
 # Import error handling utilities (still needed for decorators and validation)
+from src.content_manager import ContentValidationError
 from src.error_handler import ErrorCode, ValidationError, with_error_handling
 
 # Import service container and configuration factory
@@ -205,9 +208,9 @@ def prevent_event_overflow(event_type: str = "generic"):
 try:
     content_manager.load_prompts_from_yaml()
     logger.info(f"Loaded {content_manager.get_prompt_count()} prompts from YAML")
-except Exception as e:
-    logger.error(f"Failed to load prompts: {e}")
-    # Continue without prompts for now - will handle gracefully
+except (FileNotFoundError, yaml.YAMLError, ContentValidationError) as e:
+    logger.critical(f"FATAL: Prompt file validation failed, which is critical for game play. Server shutting down. Error: {e}")
+    sys.exit(1)
 
 @app.route('/')
 def index():

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -3,6 +3,30 @@ Gunicorn configuration for LLMpostor application.
 Optimized for Socket.IO with eventlet workers.
 """
 
+import sys
+import logging
+import yaml
+from src.content_manager import ContentManager, ContentValidationError
+
+def on_starting(server):
+    """
+    Server hook that runs when the master process is starting.
+    We use this to validate the prompts YAML file before workers are forked.
+    If validation fails, we exit, preventing the server from starting.
+    """
+    logger = logging.getLogger(__name__)
+    logger.info("Validating prompts.yaml before starting workers...")
+    try:
+        # We need to create a temporary instance of ContentManager for validation
+        content_manager = ContentManager()
+        content_manager.load_prompts_from_yaml()
+        if content_manager.get_prompt_count() == 0:
+            raise ContentValidationError("Prompt file is empty or contains no prompts.")
+        logger.info(f"Successfully validated and loaded {content_manager.get_prompt_count()} prompts.")
+    except (FileNotFoundError, yaml.YAMLError, ContentValidationError) as e:
+        logger.critical(f"FATAL: Prompt file validation failed. Server shutting down. Error: {e}")
+        sys.exit(1)
+
 from config_factory import load_config
 
 # Load configuration (renamed to avoid conflicts with gunicorn's internal 'config')

--- a/prompts.yaml
+++ b/prompts.yaml
@@ -366,13 +366,13 @@ prompts:
     responses:
       - "23 pairs (excluding the trivial within-twin match; otherwise 1 pair already suffices)."
 
-  - id: "prompt_051"
+  - id: "prompt_052"
     prompt: "How many pairs of twins do you need in a room for there to be at least a 50% chance that two people have the same birthday? Answer in 15 words or less."
     model: "Gemini Flash 2.5"
     responses:
       - "You need 12 pairs of twins (24 people total) for at least a 50% chance."
 
-  - id: "prompt_052"
+  - id: "prompt_053"
     prompt: "How many pairs of twins do you need in a room for there to be at least a 50% chance that two people have the same birthday? Answer in 15 words or less."
     model: "Grok 3"
     responses:


### PR DESCRIPTION
## Description

This pull request modifies the server's startup behavior to treat errors during prompt file (`prompts.yaml`) loading as fatal. This prevents the application from starting in a broken state.

### Changes

1.  **Added `on_starting` Gunicorn Server Hook:** A new server hook has been added to `gunicorn.conf.py`. This hook validates the `prompts.yaml` file *before* any worker processes are started. If any validation error occurs (e.g., file not found, malformed YAML, duplicate prompt IDs), a critical error is logged, and the Gunicorn master process exits. This prevents the server from starting at all if the prompt data is invalid.

2.  **Maintained Worker-Level Validation:** The fatal error handling within the main application (`app.py`) remains. This ensures that if a worker were to start with an invalid configuration for any reason, it would still exit immediately.

## Why This Change Was Made

Previously, a broken deployment occurred when a `prompts.yaml` file with duplicate prompt IDs was committed. The server was configured to handle this "gracefully" by logging the error and continuing to run, but without any prompts loaded.

This led to two issues:
1.  The deployment was considered "successful" even though the application was non-functional.
2.  Users attempting to start a game were met with a generic `An unexpected error occurred` message in the UI, caused by a `NO_PROMPTS_AVAILABLE` error on the backend.

An initial fix to make the error fatal within the application worker process was insufficient. It caused the worker to crash as intended, but the Gunicorn master process would immediately restart it, leading to an infinite crash loop.

This solution addresses the root cause by moving the validation to the master process itself, ensuring the server fails fast and loud, making such deployment errors immediately obvious.

## Error Fixed

-   **UI Error:** `An unexpected error occurred`
-   **Backend Error:** `NO_PROMPTS_AVAILABLE`
-   **Deployment Issue:** Prevents Gunicorn from entering an infinite worker restart loop when `prompts.yaml` is invalid.

## Primary Source Reference

This implementation uses Gunicorn's server hooks, as described in the official documentation. The `on_starting` hook is specifically designed for tasks like this that need to run once when the master process is starting.

-   [Gunicorn Server Hooks Documentation](https://docs.gunicorn.org/en/stable/settings.html#on-starting)