### PR TITLE
Fix response/guess counters initialization and updates; add tests to prevent regressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ More importantly, the prompts are designed to reveal the hidden biases that are 
 
 ### Developed with AI
 
-LLMpostor is not just a game *about* human AI interactions; it's also a product *of* human AI interactions. The initial MVP was developed by a human with the help of [Kiro](https://kiro.dev/), and subsequent (and very necessary) refactoring and feature development have been assisted by [Claude Code](https://www.anthropic.com/claude-code) and [Gemini](https://codeassist.google/). If you notice any bugs please blame the AI and not the human that naively hit merge.
+LLMpostor is not just a game *about* human AI interactions; it's also a product *of* human AI interactions. The initial MVP was developed by a human with the help of [Kiro](https://kiro.dev/), and subsequent (and very necessary) refactoring, bug fixing, & feature development have been assisted by [Claude Code](https://www.anthropic.com/claude-code), [Gemini](https://codeassist.google/), & [Windsurf](https://windsurf.com/). If you notice any bugs please blame the AI and not the human that naively hit merge.
 
 ### An Open and Evolving Platform
 


### PR DESCRIPTION
## Summary
- Fixes incorrect “Waiting for responses…” and “Waiting for guesses…” counters.
- Ensures counters initialize to 0/total at phase start and prefer server-provided counts thereafter.
- Adds unit test coverage for responding and guessing counter behavior.

## Why
The counters displayed inconsistent and confusing values at the start of phases and for other players:

- Responding phase issues:
  - First round: showed “Waiting for responses… (0/0 submitted)” until the first submission, then updated to the correct “(1/2 submitted)”.
  - Subsequent rounds (with two players): started incorrectly at “(1/2 submitted)” before anyone actually submitted.

- Cross-player sync issue:
  - After one player submitted, only that player’s counter updated; the other player remained stuck at “(0/2 submitted)” until they submitted too.

- Guessing phase had a similar class of issues with “Waiting for guesses…”.

Root cause was two-fold on the client:
- We did not initialize counters upon phase start (UI defaulted to 0/0, or stale values bled into the next round).
- After the server broadcasted accurate counts (response_submitted / guess_submitted), room_state updates could overwrite the displayed values with local fallbacks (e.g., 0 or 1) on non-submitting clients.

## What changed
Frontend logic changes (responding)
- Initialize counters at the start of responding:
  - EventManager._handleRoundStarted(): compute total players and call UIManager.updateSubmissionCount(0, total).
- Prefer server values on room_state updates:
  - EventManager._handleGameStateChange() in ‘responding’: use gameState.response_count when present; otherwise derive from hasSubmittedResponse to avoid false “1/2” at phase start.

Frontend logic changes (guessing)
- Initialize counters at the start of guessing:
  - EventManager._handleGuessingPhaseStarted(): compute total players and call UIManager.updateGuessCount(0, total).
- Prefer server values on room_state updates:
  - EventManager._handleGameStateChange() in ‘guessing’: use gameState.guess_count when present; otherwise derive from hasSubmittedGuess.

## Tests
- tests/unit/EventManager.test.js
  - New “Counters initialization and updates” suite:
    - initializes submission counter to 0/total on round start
    - prefers server response_count during responding state updates
    - falls back to local hasSubmittedResponse when server response_count is absent
    - initializes guess counter to 0/total on guessing phase start
    - prefers server guess_count during guessing state updates
    - falls back to local hasSubmittedGuess when server guess_count is absent

## Bug fixed
- First round displayed “(0/0 submitted)” until first submission, then corrected to “(1/2 submitted)”.
- Subsequent rounds (2 players) started incorrectly at “(1/2 submitted)” even before any submission.
- After a submission, only the submitting player’s count updated; the other player still saw “(0/2 submitted)”.
- Equivalent symptoms existed in the guessing phase for “Waiting for guesses…”.

## How this fix addresses it
- Counters are explicitly initialized at phase start based on the current room totals, preventing 0/0 and stale carry-over.
- During ongoing room_state updates, the UI prefers authoritative server counts (response_count / guess_count). This prevents local fallbacks from overwriting accurate broadcasted values on non-submitting clients.
- Tests lock the behavior against regression.

## Manual verification steps
- Start a round with two players:
  - Before any submission, both clients should show “Waiting for responses… (0/2 submitted)”.
  - After one submission, both should show “(1/2 submitted)”.
  - After second submission, transition to guessing.
- In guessing phase:
  - Before any guess, both clients should show “Waiting for guesses… (0/2 guessed)”.
  - After one guess, both should show “(1/2 guessed)”.
  - After second guess, transition to results.

## Risks / considerations
- Relies on server broadcasting response_count / guess_count and including them in room_state updates, which is already implemented in BroadcastService and used in production code.
- Tested at the unit level for EventManager logic; further integration tests can be added if needed.

## Changelog
- Frontend: Fix counters init and updates in responding/guessing phases; prefer server counts; add unit tests for counters.
- No backend changes.

## Checklist
- [x] Fix responding counter initialization and server-preferred updates
- [x] Fix guessing counter initialization and server-preferred updates
- [x] Add unit tests for responding and guessing counter behavior
- [x] All tests passing locally (Vitest)

## References
- templates/game.html (submission and guess counters)
- static/js/modules/UIManager.js (updateSubmissionCount, updateGuessCount)
- static/js/modules/EventManager.js (responding and guessing logic)
- app.py (handle_submit_response)
- src/services/broadcast_service.py (broadcast_response_submitted, broadcast_guess_submitted, broadcast_room_state_update)