### PR TITLE
Remove debug initialization toast from EventManager to reduce UX noise on join

### DIFF
--- a/static/js/modules/EventManager.js
+++ b/static/js/modules/EventManager.js
@@ -59,13 +59,7 @@ class EventManager extends EventBusModule {
         
         this.socket.initialize();
         this.isInitialized = true;
-        
-        // Publish initialization event
-        this.publish(Events.SYSTEM.INFO, {
-            message: 'EventManager initialized',
-            roomId,
-            timestamp: Date.now()
-        });
+
     }
     
     /**


### PR DESCRIPTION
Summary

This change removes the blue info toast “EventManager initialized” that appeared when users joined a room. The message was intended for developer/debugging visibility and did not provide actionable value to players. The green success toast “Joined room <ROOM_ID>” remains.

Why

- Users currently see two messages on room join:
  - Blue info: “EventManager initialized”
  - Green success: “Joined room Qwerty”
- Based on our discussion, the first message is developer-oriented (a lifecycle log) and adds cognitive noise for players without any user-facing value. Keeping only the explicit, user-focused event (“Joined room …”) improves clarity and reduces distraction during the critical join flow.
- This also aligns with our notification guidelines: info toasts should communicate relevant state changes or actions to the user, not internal initialization events.

What changed

- Removed publishing of the `Events.SYSTEM.INFO` event in `EventManager.initialize(...)` that previously triggered the blue toast via `ToastManager`.

Primary sources

- `static/js/modules/EventManager.js` — initialization logic and removed publish block:
```60:71:static/js/modules/EventManager.js
        this.socket.initialize();
        this.isInitialized = true;
        
        // Publish initialization event
        this.publish(Events.SYSTEM.INFO, {
            message: 'EventManager initialized',
            roomId,
            timestamp: Date.now()
        });
```

- `static/js/modules/EventManager.js` — room join success toast (intentionally retained):
```541:547:static/js/modules/EventManager.js
    _handleRoomJoined(data) {
        console.log('Joined room:', data);
        const roomData = data.success ? data.data : data;
        this.gameState.updateAfterRoomJoin(roomData);
        this.toast.success(`Joined room ${roomData.room_id}`);
    }
```

- `static/js/modules/ToastManager.js` — subscription that renders `Events.SYSTEM.INFO` as an info toast:
```32:41:static/js/modules/ToastManager.js
        this.subscribe(Events.SYSTEM.INFO, this._handleSystemInfo.bind(this));
        ...
        console.log('ToastManager initialized with EventBus integration');
```
and handler:
```358:367:static/js/modules/ToastManager.js
    _handleSystemInfo(data) {
        let message = 'System Info';
        if (typeof data === 'string') {
            message = data;
        } else if (data && data.message) {
            message = data.message;
        }
        this.info(message, false);
    }
```

Implementation details

- Edit: `static/js/modules/EventManager.js` — removed the `this.publish(Events.SYSTEM.INFO, { message: 'EventManager initialized', ... })` block from `initialize(roomId)`.
- Left existing console logging (`console.log('Initializing EventManager for room:', roomId);`) intact for developer diagnostics without surfacing to the user.
- No changes to join success behavior or other toasts.

User-visible impact

- Before: Users saw two toasts on join (info + success).
- After: Users only see the success toast “Joined room <ROOM_ID>”.

Tests and risk

- No tests reference the removed message keyword (search found no matches for “EventManager initialized” under `tests/`).
- The change only removes a publish of a system info event; it does not alter business logic, socket flows, or UI state transitions.
- Minimal risk; behavior is limited to suppressing a non-essential info notification.

Manual verification steps

1) Start the app and join a room.
2) Confirm there is no blue info toast “EventManager initialized”.
3) Confirm the green success toast “Joined room <ROOM_ID>” still appears.
4) Verify normal gameplay flows (responding, guessing, results) remain unaffected.

Changelog

- UX: Remove debug initialization info toast on room join.